### PR TITLE
Fix case-sensitive sentiment handling in get_statistics()

### DIFF
--- a/export_feedback.py
+++ b/export_feedback.py
@@ -120,9 +120,20 @@ class FeedbackExporter:
                 'average_rating': 0
             }
         
-        positive = sum(1 for f in self.feedback_list if f.get('sentiment') == 'positive')
-        neutral = sum(1 for f in self.feedback_list if f.get('sentiment') == 'neutral')
-        negative = sum(1 for f in self.feedback_list if f.get('sentiment') == 'negative')
+        positive = sum(
+            1 for f in self.feedback_list
+            if f.get('sentiment', '').lower() == 'positive'
+        )
+    
+        neutral = sum(
+            1 for f in self.feedback_list
+            if f.get('sentiment', '').lower() == 'neutral'
+        )
+    
+        negative = sum(
+            1 for f in self.feedback_list
+            if f.get('sentiment', '').lower() == 'negative'
+        )
         
         total_rating = sum(f.get('rating', 0) for f in self.feedback_list)
         avg_rating = total_rating / len(self.feedback_list) if self.feedback_list else 0


### PR DESCRIPTION

This PR fixes a case-sensitivity issue in `FeedbackExporter.get_statistics()`.

Previously, sentiment values were compared using exact string matching
(example `== "positive"`). This caused incorrect statistics when sentiment
values were provided in different cases (example `"Positive"`, `"POSITIVE"`).

## Changes

- Updated sentiment comparisons in `get_statistics()` to use
  case-insensitive matching via `.lower()`
- Ensured behavior is consistent with `filter_by_sentiment()`,
  which already performs case-insensitive comparison

## Example

Before:
- "Positive"  not counted as positive

After:
- "Positive", "POSITIVE", "positive"  now all counted correctly


